### PR TITLE
Curries `add` function in point-free style code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ executions with the the same input parameters.
 ```js
 // Given
 let map = fn => list => list.map(fn);
-let add = (a, b) => a + b;
+let add = a => b => a + b;
 
 // Then
 


### PR DESCRIPTION
The `add` function needs to be curried in order for the code example to work.