### PR TITLE
add Hindley-Milner reference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -511,7 +511,7 @@ TODO
 
 Often functions will include comments that indicate the types of their arguments and return types.
 
-There's quite a bit of variance across the community but they often follow the following patterns:
+There's quite a bit of variance across the community but they often follow the following patterns, written in the Hindley-Milner type system:
 
 ```js
 // functionName :: firstArgType -> secondArgType -> returnType


### PR DESCRIPTION
Wanted to add a reference to Hindley-Milner in the type signature section, in case readers of this document want to learn more about the system.