### PR TITLE
Typo Fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -329,8 +329,8 @@ and
 const f = x => x + 1
 const g = x => x * 2
 
-;[1, 2, 3].map(x => f(g(x))) // = [3, 5, 7]
-;[1, 2, 3].map(g).map(f)     // = [3, 5, 7]
+[1, 2, 3].map(x => f(g(x))) // = [3, 5, 7]
+[1, 2, 3].map(g).map(f)     // = [3, 5, 7]
 ```
 
 ## Pointed Functor
@@ -349,7 +349,7 @@ Lifting is when you take a value and put it into an object like a [functor](#poi
 Some implementations have a function called `lift`, or `liftA2` to make it easier to run functions on functors.
 
 ```js
-const liftA2 = (f) => (a, b) => a.map(f).ap(b)
+const liftA2 = (f) => (a, b) => a.map(f).map(b)
 
 const mult = a => b => a * b
 


### PR DESCRIPTION
- Remove unnecessary semicolons in Functor example
- Fix "map" typo in Lift example