### PR TITLE
fix: arrow function in setoid

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -675,7 +675,7 @@ An object that has an `equals` function which can be used to compare other objec
 Make array a setoid:
 
 ```js
-Array.prototype.equals = (arr) => {
+Array.prototype.equals = function (arr) {
   const len = this.length
   if (len !== arr.length) {
     return false


### PR DESCRIPTION
An arrow function expression does not bind its own this hence `this` is not array.

Expected: true false
Actually:   false false