### PR TITLE
Add line after code block to fix inline code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@ const addTo = x => y => x + y
 var addToFive = addTo(5)
 addToFive(3) // returns 8
 ```
+
 The function `addTo()` returns a function(internally called `add()`), lets store it in a variable called `addToFive` with a curried call having parameter 5.
 
 Ideally, when the function `addTo` finishes execution, its scope, with local variables add, x, y should not be accessible. But, it returns 8 on calling `addToFive()`. This means that the state of the function `addTo` is saved even after the block of code has finished executing, otherwise there is no way of knowing that `addTo` was called as `addTo(5)` and the value of x was set to 5.


### PR DESCRIPTION
https://functional.works-hub.com/blog/Functional-Programming-Jargon 

The line below is shown instead of having the single backticks in the md rendered into inline code.

> The function \`\`\`addTo()\`\`\` returns a function(internally called \`\`\`add()\`\`\`), lets