### PR TITLE
Adding Rust world

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ __Translations__
 * [Chinese](https://github.com/shfshanyue/fp-jargon-zh)
 * [Bahasa Indonesia](https://github.com/wisn/jargon-pemrograman-fungsional)
 * [Scala World](https://github.com/ikhoon/functional-programming-jargon.scala)
+* [Rust World](https://github.com/JasonShin/functional-programming-jargon.rs)
 * [Korean](https://github.com/sphilee/functional-programming-jargon)
 
 __Table of Contents__


### PR DESCRIPTION
Hi, I've worked on a Rust world version of the Jargon project recently as a side project.

I think the Rust variation will be an interesting addition to the Functional Programming Jargon projects family for the following reasons
- Rust is gaining a lot of tractions
- Although it may seem like it supports functional programming features, it does not have Higher Kinded Type, currying, auto-currying and subtyping. functional-programming-jargon.rs provides workarounds to these problems
- An attempt to emulate the Haskell ecosystem in a system-level programming language