### PR TITLE
Update kleisi-composition comment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -743,7 +743,7 @@ const parseAndValidate = kleisliCompose(validatePositive, safeParseNum)
 
 parseAndValidate('1') // => Some(1)
 parseAndValidate('asdf') // => None
-parseAndValidate('999') // => None
+parseAndValidate('999') // => Some(999)
 ```
 
 This works because:


### PR DESCRIPTION
Change the comment for the return value for the kleisi-composition.

In my understanding and in my personal tests 

> parseAndValidate("999")

must return 999 instead of None. 1. it is a number and 2. the number is positive. Please correct me if I'am wrong.